### PR TITLE
Variable extension

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -50,3 +50,6 @@ values for that variable:
         [:X :Y :Z])
 ```
 
+Note that the variables apply to all keywords in the grammar.  
+This includes the [rule heads](selection.md) and [modifiers](modifiers.md).  
+This means that you can e.g. attach a pirate accent to certain characters etc.

--- a/src/cljc/grotesque/generation.cljc
+++ b/src/cljc/grotesque/generation.cljc
@@ -76,6 +76,7 @@
    See the docstring for `grotesque.core/create-grammar` for more info on the generation of the grammar
    and the docstring for `grotesque.core/generate` for more info on the generation of the starting-vector."
   [grammar starting-vector]
-  (let [[grammar root] (make-generation-tree grammar starting-vector)
-        output-text    (join-generation-tree grammar root)]
-    (assoc grammar :generated output-text)))
+  (let [[grammar root] (make-generation-tree grammar starting-vector)]
+    (if (-> grammar :errors empty?)
+      (assoc grammar :generated (join-generation-tree grammar root))
+      grammar)))

--- a/src/cljc/grotesque/generation.cljc
+++ b/src/cljc/grotesque/generation.cljc
@@ -14,10 +14,8 @@
 
 (defn- invoke-rule
   "Returns the results of a rule invocation (a map)."
-  [grammar non-terminal]
-  (let [invoked             (name non-terminal)
-        [head & modifiers] (->> (string/split invoked #"\.")
-                                (map keyword))
+  [grammar [head & modifiers]]
+  (let [invoked             (string/join "." (map name (concat [head] modifiers)))
         selector-fn         (selection/get-selector-fn grammar)
         grammar             (dissoc grammar :selected)
         updated-grammar     (util/try-catch

--- a/src/cljc/grotesque/rules.cljc
+++ b/src/cljc/grotesque/rules.cljc
@@ -1,6 +1,5 @@
 (ns grotesque.rules
-  (:require [clojure.string :as string]
-            [grotesque.util :as util]))
+  (:require [grotesque.util :as util]))
 
 (defn parse-tag
   "Accepted tags are in vector, keyword or string forms.
@@ -14,10 +13,8 @@
   [rule part]
   (if (vector? part)
     (update rule :tags #(conj (vec %) (vec part)))
-    (-> (name part)
-        (string/split #"\.")
-        (->> (mapv keyword)
-             (recur rule)))))
+    (->> (util/split-keyword part)
+         (recur rule))))
 
 (defn parse-body
   "Accepts bodies in vector or string forms.

--- a/src/cljc/grotesque/schema.cljc
+++ b/src/cljc/grotesque/schema.cljc
@@ -5,7 +5,9 @@
 (def RuleBody
   "A schema for a grotesque rule body."
   {:id                    s/Keyword
-   (s/optional-key :text) [(s/pred #(or (string? %) (keyword? %)))]
+   (s/optional-key :text) [(s/pred #(or (string? %)
+                                        (and (vector? %)
+                                             (every? keyword? %))))]
    (s/optional-key :tags) [[s/Keyword]]})
 
 (def Grammar

--- a/src/cljc/grotesque/util.cljc
+++ b/src/cljc/grotesque/util.cljc
@@ -30,6 +30,14 @@
           (dissoc :selected)
           (add-error (str message "\n" #?(:clj (.getMessage e) :cljs e)))))))
 
+(defn split-keyword
+  "Splits a keyword into a vector of keywords using the period as a separator."
+  [k]
+  (-> (cond-> k
+        (keyword? k) name)
+      (string/split #"\.")
+      (->> (mapv keyword))))
+
 (defn parse-symbol-string
   "Returns a vector representation of the terminal and non-terminal symbols in the given string.
    E.g. \"There is an #animal# here.\" => [\"There is an \" :animal \" here.\"]
@@ -38,7 +46,10 @@
   (if (string? s)
     (->> (string/split s #"(\[|\]|#)")
          (remove #{"[" "]" "#"}) ; ClojureScript split leaves the separators sometimes
-         (map #(if (even? %1) %2 (keyword %2)) (range))
+         (map #(if (even? %1) ; Every odd indexed element is a tag
+                 %2
+                 (split-keyword %2))
+              (range))
          (remove #(or (= nil %) (= "" %)))
          vec)
     ""))

--- a/src/cljc/grotesque/variables.cljc
+++ b/src/cljc/grotesque/variables.cljc
@@ -29,7 +29,7 @@
   [grammar rule-body]
   (if-let [fns (-> grammar :functions :variable-fns)]
     (let [part-set (-> fns keys set)
-          vars     (->> rule-body :tags flatten distinct (filter part-set))]
+          vars     (->> rule-body ((juxt :tags :text)) flatten distinct (filter part-set))]
       (->> vars
            (map #((get fns %) grammar %))
            (apply combo/cartesian-product)

--- a/test/cljc/grotesque/core_test.cljc
+++ b/test/cljc/grotesque/core_test.cljc
@@ -38,8 +38,7 @@
                  (grotesque/generate "#S#")
                  (select-keys [:errors :generated]))
              {:errors    ["Error while invoking 'b':\nNo rule 'b' found, a possible typo?"
-                          "No valid rule 'b' found"]
-              :generated "textS textA  textC"}))
+                          "No valid rule 'b' found"]}))
 
 (deftest selectors
   (let [meta-selector-fn (fn [grammar head bodies]
@@ -57,7 +56,7 @@
 
 (deftest modifiers
   (is (= "Mash three pearrrs."
-         (-> {:food ["pear"]
+         (-> {:food          ["pear"]
               :pirate-recipe ["Mash three #food.pirate.plural#."]}
              (grotesque/create-grammar)
              (grotesque/set-modifier :pirate #(string/replace % #"[aeiouy]r" "$0rr"))

--- a/test/cljc/grotesque/core_test.cljc
+++ b/test/cljc/grotesque/core_test.cljc
@@ -80,4 +80,14 @@
              (grotesque/set-variable :X (constantly [:kitten :puppy]))
              (grotesque/set-variable :Y (constantly [:cat :dog]))
              (grotesque/generate "#combination#")
-             :selected))))
+             :selected)))
+
+  (is (= "This is HUNGARY."
+         (-> {:country ["Hungary"]
+              :test    ["This is #X.Y#."]}
+             grotesque/create-grammar
+             (grotesque/set-modifier :upper string/upper-case)
+             (grotesque/set-variable :X (constantly [:country]))
+             (grotesque/set-variable :Y (constantly [:upper]))
+             (grotesque/generate "#test#")
+             :generated))))

--- a/test/cljc/grotesque/model_test.cljc
+++ b/test/cljc/grotesque/model_test.cljc
@@ -38,8 +38,7 @@
                  (model/set-effect-handler :test-fx (fn [_ _ _] (util/throw-cljc "ERROR-2")))
                  (grotesque/generate "#S#")
                  (select-keys [:errors :generated]))
-             {:generated "sss"
-              :errors    ["Error while invoking 'A':\nCondition error in rule ':A-0' in tag ':test-cnd.random':\nERROR-1"
+             {:errors    ["Error while invoking 'A':\nCondition error in rule ':A-0' in tag ':test-cnd.random':\nERROR-1"
                           "No valid rule 'A' found"
                           "Error while invoking 'B':\nEffect error in rule ':B-0' in tag ':test-fx.random':\nERROR-2"
                           "No valid rule 'B' found"]}))

--- a/test/cljc/grotesque/test_utils.cljc
+++ b/test/cljc/grotesque/test_utils.cljc
@@ -50,7 +50,7 @@
   {:color [{:id :color-0, :text ["black"], :tags [[:when :time :night]]}
            {:id :color-1, :text ["red"], :tags [[:when :time :evening]]}
            {:id :color-2, :text ["blue"], :tags [[:when :time :day]]}],
-  :sky   [{:id :sky-0, :text [:color " sky"]}]
+  :sky   [{:id :sky-0, :text [[:color] " sky"]}]
   :they  [{:id :they-0, :text ["he"], :tags [[:when :actor :gender :he]]}
           {:id :they-1, :text ["she"], :tags [[:when :actor :gender :she]]}
           {:id :they-2, :text ["they"], :tags [[:when :actor :gender :they]]}]
@@ -64,4 +64,4 @@
                {:id :set-gender-1, :tags [[:set :actor :gender :she]]}
                {:id :set-gender-2, :tags [[:set :actor :gender :they]]}],
   :story      [{:id :story-0,
-                :text [:set-time :set-gender "The " :sky " was looming overhead. So " :they " adjusted " :their " glasses."]}]})
+                :text [[:set-time] [:set-gender] "The " [:sky] " was looming overhead. So " [:they] " adjusted " [:their] " glasses."]}]})

--- a/test/cljc/grotesque/util_test.cljc
+++ b/test/cljc/grotesque/util_test.cljc
@@ -7,9 +7,9 @@
   (are [s v] (= v (util/parse-symbol-string s))
              "" []
              "abc" ["abc"]
-             "Hello #world#" ["Hello " :world]
-             "Hello [world.state]" ["Hello " :world.state]
-             "#A-1##B#cde#FG#hi" [:A-1 :B "cde" :FG "hi"]))
+             "Hello #world#" ["Hello " [:world]]
+             "Hello [world.state]" ["Hello " [:world :state]]
+             "#A-1##B#cde#FG#hi" [[:A-1] [:B] "cde" [:FG] "hi"]))
 
 (deftest try-catch
   (is (= {:errors ["catched-msg\nthrown-msg"]}


### PR DESCRIPTION
Extends the variables to affect the rule head and modiifers.
This means that you can e.g. attach a pirate accent to all pirates.